### PR TITLE
Updated platform to .NET 6 and TFTLT patch 2.03

### DIFF
--- a/Patches.cs
+++ b/Patches.cs
@@ -91,10 +91,11 @@ namespace ShorterReadingIntervals {
 
 		[HarmonyPatch(typeof(ResearchItem), "OnResearchComplete", new Type[0])]
 		private static class PreventDoubleSkillPointsBeingAwarded {
-			internal static bool Prefix(ResearchItem __instance) {
-				// Only run the original - and award skill points - if the item type is still Tool and not yet FireStarting
-				var isTool = __instance.GetComponent<GearItem>()?.IsGearType(GearType.Tool);
-				return isTool.GetValueOrDefault();
+
+			internal static void Postfix(ResearchItem __instance) {                
+				// Necessary to prevent skill points being applied twice when the method is run again
+                __instance.m_SkillPoints = 0;
+				__instance.m_SkillType = SkillType.None;
 			}
 		}
 

--- a/Patches.cs
+++ b/Patches.cs
@@ -1,6 +1,8 @@
 ﻿using System;
-using Harmony;
+using HarmonyLib;
 using UnityEngine;
+using Il2Cpp;
+using Il2CppTLD.Gear;
 
 namespace ShorterReadingIntervals {
 	internal static class Patches {
@@ -91,7 +93,8 @@ namespace ShorterReadingIntervals {
 		private static class PreventDoubleSkillPointsBeingAwarded {
 			internal static bool Prefix(ResearchItem __instance) {
 				// Only run the original - and award skill points - if the item type is still Tool and not yet FireStarting
-				return __instance.GetComponent<GearItem>()?.m_Type == GearTypeEnum.Tool;
+				var isTool = __instance.GetComponent<GearItem>()?.IsGearType(GearType.Tool);
+				return isTool.GetValueOrDefault();
 			}
 		}
 

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -12,7 +12,14 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("2878cf6b-b84b-4573-8185-12a5654f0496")]
-[assembly: AssemblyVersion("1.3.0.0")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
-[assembly: MelonInfo(typeof(ShorterReadingIntervals.ShorterReadingIntervalsMod), "ShorterReadingIntervals", "1.3", "zeobviouslyfakeacc")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: MelonInfo(typeof(ShorterReadingIntervals.ShorterReadingIntervalsMod), BuildInfo.ModName, BuildInfo.ModVersion, BuildInfo.ModAuthor)]
 [assembly: MelonGame("Hinterland", "TheLongDark")]
+
+internal static class BuildInfo
+{
+    internal const string ModName = "ShorterReadingIntervals";
+    internal const string ModAuthor = "zeobviouslyfakeacc";
+    internal const string ModVersion = "2.0";
+}

--- a/ShorterReadingIntervals.csproj
+++ b/ShorterReadingIntervals.csproj
@@ -1,69 +1,35 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{2878CF6B-B84B-4573-8185-12A5654F0496}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ShorterReadingIntervals</RootNamespace>
-    <AssemblyName>ShorterReadingIntervals</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Il2Cppmscorlib">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Il2CppSystem">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="MelonLoader.ModHandler">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="ModSettings">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="UnhollowerBaseLib">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnhollowerRuntimeLib">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule">
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Patches.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="ReadingSettings.cs" />
-    <Compile Include="ShorterReadingIntervalsMod.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<!--This is an xml comment. Comments have no impact on compiling.-->
+
+	<PropertyGroup>
+		<!--This is the .NET version the mod will be compiled with. Don't change it.-->
+		<TargetFramework>net6.0</TargetFramework>
+
+		<!--This tells the compiler to use the latest C# version.-->
+		<LangVersion>Latest</LangVersion>
+
+		<!--This adds global usings for a few common System namespaces.-->
+		<ImplicitUsings>enable</ImplicitUsings>
+
+		<!--This enables nullable annotation and analysis. It's good coding form.-->
+		<Nullable>enable</Nullable>
+
+		<!--This tells the compiler to use assembly attributes instead of generating its own.-->
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+
+		<!--PDB files give line numbers in stack traces (errors). This is useful for debugging. There are 3 options:-->
+		<!--full has a pdb file created beside the dll.-->
+		<!--embedded has the pdb data embedded within the dll. This is useful because bug reports will then have line numbers.-->
+		<!--none skips creation of pdb data.-->
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
+
+	<!--This is the of packages that the mod references.-->
+	<ItemGroup>
+		<!--This package contains almost everything a person could possibly need to reference while modding.-->
+		<PackageReference Include="STBlade.Modding.TLD.Il2CppAssemblies.Windows" Version="2.10.0" />		
+		<PackageReference Include="STBlade.Modding.TLD.ModSettings" Version="1.9.0" />
+		<!--The package version here in this template may be outdated and need to be updated. Visual Studio can update package versions automatically.-->
+		<!--If the mod references any other mods (such as ModSettings), that NuGet package will also need to be listed here.-->
+	</ItemGroup>
 </Project>

--- a/ShorterReadingIntervalsMod.cs
+++ b/ShorterReadingIntervalsMod.cs
@@ -3,9 +3,11 @@ using UnityEngine;
 
 namespace ShorterReadingIntervals {
 	internal class ShorterReadingIntervalsMod : MelonMod {
-		public override void OnApplicationStart() {
+
+		public override void OnInitializeMelon() {
 			Settings.OnLoad();
 			Debug.Log($"[{Info.Name}] version {Info.Version} loaded!");
-		}
+            new MelonLoader.MelonLogger.Instance($"{Info.Name}").Msg($"Version {Info.Version} loaded");
+        }
 	}
 }


### PR DESCRIPTION
Update to make ShorterReadingIntervals compatible with the post-TFTFT release. Tested on latest game version 2.14.

Limited changes:
 - Updated assemblies and dependencies for newest version of MelonLoader and .NET 6
 - Changed a single different gear API call